### PR TITLE
Check "matched" video URL before assigning

### DIFF
--- a/lib/ym_posts/models/post.rb
+++ b/lib/ym_posts/models/post.rb
@@ -52,8 +52,11 @@ module YmPosts::Post
   def extract_video_url
     if video_url.blank? && text.present?
       if matches = (text.match(YmVideos::YOUTUBE_REGEX) || text.match(YmVideos::VIMEO_REGEX))
-        self.video_url = "https://#{matches[0]}"
-      end  
+        match_url = "https://#{matches[0]}"
+        if VideoInfo.new(match_url).available?
+          self.video_url = match_url
+        end
+      end
     end
   end
   


### PR DESCRIPTION
Only assign the post video url if we are sure that it is a video and is
available.
